### PR TITLE
pretty-git: update to 0.1.3

### DIFF
--- a/Formula/pretty-git.rb
+++ b/Formula/pretty-git.rb
@@ -1,25 +1,26 @@
 class PrettyGit < Formula
   desc "Git repository analytics and reporting CLI"
   homepage "https://github.com/MikoMikocchi/pretty-git"
-  url "https://rubygems.org/downloads/pretty-git-0.1.2.gem"
-  sha256 "f35e9777afd915caf43f03e10ea6f094e922121c8159179a807fbe8ab1fd5f2e"
+  url "https://rubygems.org/downloads/pretty-git-0.1.3.gem"
+  sha256 ""
   license "MIT"
+  revision 1
 
   livecheck do
-    url "https://rubygems.org/gems/pretty-git"
+  url "https://rubygems.org/downloads/pretty-git-0.1.3.gem"
     strategy :rubygems
   end
 
   depends_on "ruby"
 
   resource "csv" do
-    url "https://rubygems.org/downloads/csv-3.3.5.gem"
-    sha256 "6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f"
+  url "https://rubygems.org/downloads/pretty-git-0.1.3.gem"
+  sha256 ""
   end
 
   resource "rexml" do
-    url "https://rubygems.org/downloads/rexml-3.4.1.gem"
-    sha256 "c74527a9a0a04b4ec31dbe0dc4ed6004b960af943d8db42e539edde3a871abca"
+  url "https://rubygems.org/downloads/pretty-git-0.1.3.gem"
+  sha256 ""
   end
 
   def install


### PR DESCRIPTION
Automated update of formula for pretty-git 0.1.3.
- url: https://rubygems.org/downloads/pretty-git-0.1.3.gem
- sha256: 
This PR was generated by the Release workflow.